### PR TITLE
Fix #7: Add support for colored and transparent primitives

### DIFF
--- a/airo_models/primitives/box.py
+++ b/airo_models/primitives/box.py
@@ -1,6 +1,6 @@
 """Python functions to easily generate parametrized URDF boxes."""
 
-from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile, material_dict
+from airo_models.urdf import dict_to_xml_str, material_dict, single_link_urdf_dict, write_urdf_to_tempfile
 
 
 def box_geometry_dict(size: tuple[float, float, float]) -> dict:
@@ -8,23 +8,26 @@ def box_geometry_dict(size: tuple[float, float, float]) -> dict:
     return geometry_dict
 
 
-def box_dict(size: tuple[float, float, float], name: str = "box",
-             rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> dict:
+def box_dict(
+    size: tuple[float, float, float], name: str = "box", rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)
+) -> dict:
     geometry_dict = box_geometry_dict(size)
     mat_dict = material_dict(rgba)
     box_dict_ = single_link_urdf_dict(name, geometry_dict, mat_dict)
     return box_dict_
 
 
-def box_urdf(size: tuple[float, float, float], name: str = "box",
-             rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+def box_urdf(
+    size: tuple[float, float, float], name: str = "box", rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)
+) -> str:
     box_dict_ = box_dict(size, name, rgba)
     urdf_str = dict_to_xml_str(box_dict_)
     return urdf_str
 
 
-def box_urdf_path(size: tuple[float, float, float], name: str = "box",
-                  rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+def box_urdf_path(
+    size: tuple[float, float, float], name: str = "box", rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)
+) -> str:
     urdf_path = write_urdf_to_tempfile(box_dict(size, name, rgba), prefix=f"{name}_")
     return urdf_path
 

--- a/airo_models/primitives/box.py
+++ b/airo_models/primitives/box.py
@@ -1,6 +1,6 @@
 """Python functions to easily generate parametrized URDF boxes."""
 
-from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile
+from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile, material_dict
 
 
 def box_geometry_dict(size: tuple[float, float, float]) -> dict:
@@ -8,20 +8,24 @@ def box_geometry_dict(size: tuple[float, float, float]) -> dict:
     return geometry_dict
 
 
-def box_dict(size: tuple[float, float, float], name: str = "box") -> dict:
+def box_dict(size: tuple[float, float, float], name: str = "box",
+             rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> dict:
     geometry_dict = box_geometry_dict(size)
-    box_dict_ = single_link_urdf_dict(name, geometry_dict)
+    mat_dict = material_dict(rgba)
+    box_dict_ = single_link_urdf_dict(name, geometry_dict, mat_dict)
     return box_dict_
 
 
-def box_urdf(size: tuple[float, float, float], name: str = "box") -> str:
-    box_dict_ = box_dict(size, name)
+def box_urdf(size: tuple[float, float, float], name: str = "box",
+             rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+    box_dict_ = box_dict(size, name, rgba)
     urdf_str = dict_to_xml_str(box_dict_)
     return urdf_str
 
 
-def box_urdf_path(size: tuple[float, float, float], name: str = "box") -> str:
-    urdf_path = write_urdf_to_tempfile(box_dict(size, name), prefix=f"{name}_")
+def box_urdf_path(size: tuple[float, float, float], name: str = "box",
+                  rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+    urdf_path = write_urdf_to_tempfile(box_dict(size, name, rgba), prefix=f"{name}_")
     return urdf_path
 
 

--- a/airo_models/primitives/cylinder.py
+++ b/airo_models/primitives/cylinder.py
@@ -1,6 +1,6 @@
 """Python functions to easily generate parametrized URDF cylinders."""
 
-from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile, material_dict
+from airo_models.urdf import dict_to_xml_str, material_dict, single_link_urdf_dict, write_urdf_to_tempfile
 
 
 def cylinder_geometry_dict(length: float, radius: float) -> dict:
@@ -8,23 +8,35 @@ def cylinder_geometry_dict(length: float, radius: float) -> dict:
     return geometry_dict
 
 
-def cylinder_dict(length: float, radius: float, name: str = "cylinder",
-                  rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> dict:
+def cylinder_dict(
+    length: float,
+    radius: float,
+    name: str = "cylinder",
+    rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0),
+) -> dict:
     geometry_dict = cylinder_geometry_dict(length, radius)
     mat_dict = material_dict(rgba)
     cylinder_dict_ = single_link_urdf_dict(name, geometry_dict, mat_dict)
     return cylinder_dict_
 
 
-def cylinder_urdf(length: float, radius: float, name: str = "cylinder",
-                  rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+def cylinder_urdf(
+    length: float,
+    radius: float,
+    name: str = "cylinder",
+    rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0),
+) -> str:
     cylinder_dict_ = cylinder_dict(length, radius, name, rgba)
     urdf_str = dict_to_xml_str(cylinder_dict_)
     return urdf_str
 
 
-def cylinder_urdf_path(length: float, radius: float, name: str = "cylinder",
-                       rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+def cylinder_urdf_path(
+    length: float,
+    radius: float,
+    name: str = "cylinder",
+    rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0),
+) -> str:
     urdf_path = write_urdf_to_tempfile(cylinder_dict(length, radius, name, rgba), prefix=f"{name}_")
     return urdf_path
 

--- a/airo_models/primitives/cylinder.py
+++ b/airo_models/primitives/cylinder.py
@@ -1,6 +1,6 @@
 """Python functions to easily generate parametrized URDF cylinders."""
 
-from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile
+from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile, material_dict
 
 
 def cylinder_geometry_dict(length: float, radius: float) -> dict:
@@ -8,20 +8,24 @@ def cylinder_geometry_dict(length: float, radius: float) -> dict:
     return geometry_dict
 
 
-def cylinder_dict(length: float, radius: float, name: str = "cylinder") -> dict:
+def cylinder_dict(length: float, radius: float, name: str = "cylinder",
+                  rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> dict:
     geometry_dict = cylinder_geometry_dict(length, radius)
-    cylinder_dict_ = single_link_urdf_dict(name, geometry_dict)
+    mat_dict = material_dict(rgba)
+    cylinder_dict_ = single_link_urdf_dict(name, geometry_dict, mat_dict)
     return cylinder_dict_
 
 
-def cylinder_urdf(length: float, radius: float, name: str = "cylinder") -> str:
-    cylinder_dict_ = cylinder_dict(length, radius, name)
+def cylinder_urdf(length: float, radius: float, name: str = "cylinder",
+                  rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+    cylinder_dict_ = cylinder_dict(length, radius, name, rgba)
     urdf_str = dict_to_xml_str(cylinder_dict_)
     return urdf_str
 
 
-def cylinder_urdf_path(length: float, radius: float, name: str = "cylinder") -> str:
-    urdf_path = write_urdf_to_tempfile(cylinder_dict(length, radius, name), prefix=f"{name}_")
+def cylinder_urdf_path(length: float, radius: float, name: str = "cylinder",
+                       rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+    urdf_path = write_urdf_to_tempfile(cylinder_dict(length, radius, name, rgba), prefix=f"{name}_")
     return urdf_path
 
 

--- a/airo_models/primitives/mesh.py
+++ b/airo_models/primitives/mesh.py
@@ -1,7 +1,6 @@
 """Python functions to easily generate a single-link URDF from a mesh file."""
 
-from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile, material_dict
-
+from airo_models.urdf import dict_to_xml_str, material_dict, single_link_urdf_dict, write_urdf_to_tempfile
 
 def mesh_geometry_dict(mesh_file: str) -> dict:
     geometry_dict = {"mesh": {"@filename": mesh_file}}

--- a/airo_models/primitives/mesh.py
+++ b/airo_models/primitives/mesh.py
@@ -1,6 +1,6 @@
 """Python functions to easily generate a single-link URDF from a mesh file."""
 
-from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile
+from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile, material_dict
 
 
 def mesh_geometry_dict(mesh_file: str) -> dict:
@@ -10,7 +10,8 @@ def mesh_geometry_dict(mesh_file: str) -> dict:
 
 def mesh_dict(mesh_file: str, name: str = "mesh") -> dict:
     geometry_dict = mesh_geometry_dict(mesh_file)
-    mesh_dict_ = single_link_urdf_dict(name, geometry_dict)
+    mat_dict = material_dict((1.0, 1.0, 1.0, 1.0))
+    mesh_dict_ = single_link_urdf_dict(name, geometry_dict, mat_dict)
     return mesh_dict_
 
 

--- a/airo_models/primitives/mesh.py
+++ b/airo_models/primitives/mesh.py
@@ -2,6 +2,7 @@
 
 from airo_models.urdf import dict_to_xml_str, material_dict, single_link_urdf_dict, write_urdf_to_tempfile
 
+
 def mesh_geometry_dict(mesh_file: str) -> dict:
     geometry_dict = {"mesh": {"@filename": mesh_file}}
     return geometry_dict

--- a/airo_models/primitives/sphere.py
+++ b/airo_models/primitives/sphere.py
@@ -1,6 +1,6 @@
 """Python functions to easily generate parametrized URDF spheres."""
 
-from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile, material_dict
+from airo_models.urdf import dict_to_xml_str, material_dict, single_link_urdf_dict, write_urdf_to_tempfile
 
 
 def sphere_geometry_dict(radius: float) -> dict:
@@ -8,23 +8,26 @@ def sphere_geometry_dict(radius: float) -> dict:
     return geometry_dict
 
 
-def sphere_dict(radius: float, name: str = "sphere",
-                rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> dict:
+def sphere_dict(
+    radius: float, name: str = "sphere", rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)
+) -> dict:
     geometry_dict = sphere_geometry_dict(radius)
     mat_dict = material_dict(rgba)
     sphere_dict_ = single_link_urdf_dict(name, geometry_dict, mat_dict)
     return sphere_dict_
 
 
-def sphere_urdf(radius: float, name: str = "sphere",
-                rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+def sphere_urdf(
+    radius: float, name: str = "sphere", rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)
+) -> str:
     sphere_dict_ = sphere_dict(radius, name, rgba)
     urdf_str = dict_to_xml_str(sphere_dict_)
     return urdf_str
 
 
-def sphere_urdf_path(radius: float, name: str = "sphere",
-                     rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+def sphere_urdf_path(
+    radius: float, name: str = "sphere", rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)
+) -> str:
     urdf_path = write_urdf_to_tempfile(sphere_dict(radius, name, rgba), prefix=f"{name}_")
     return urdf_path
 

--- a/airo_models/primitives/sphere.py
+++ b/airo_models/primitives/sphere.py
@@ -1,6 +1,6 @@
 """Python functions to easily generate parametrized URDF spheres."""
 
-from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile
+from airo_models.urdf import dict_to_xml_str, single_link_urdf_dict, write_urdf_to_tempfile, material_dict
 
 
 def sphere_geometry_dict(radius: float) -> dict:
@@ -8,20 +8,24 @@ def sphere_geometry_dict(radius: float) -> dict:
     return geometry_dict
 
 
-def sphere_dict(radius: float, name: str = "sphere") -> dict:
+def sphere_dict(radius: float, name: str = "sphere",
+                rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> dict:
     geometry_dict = sphere_geometry_dict(radius)
-    sphere_dict_ = single_link_urdf_dict(name, geometry_dict)
+    mat_dict = material_dict(rgba)
+    sphere_dict_ = single_link_urdf_dict(name, geometry_dict, mat_dict)
     return sphere_dict_
 
 
-def sphere_urdf(radius: float, name: str = "sphere") -> str:
-    sphere_dict_ = sphere_dict(radius, name)
+def sphere_urdf(radius: float, name: str = "sphere",
+                rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+    sphere_dict_ = sphere_dict(radius, name, rgba)
     urdf_str = dict_to_xml_str(sphere_dict_)
     return urdf_str
 
 
-def sphere_urdf_path(radius: float, name: str = "sphere") -> str:
-    urdf_path = write_urdf_to_tempfile(sphere_dict(radius, name), prefix=f"{name}_")
+def sphere_urdf_path(radius: float, name: str = "sphere",
+                     rgba: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)) -> str:
+    urdf_path = write_urdf_to_tempfile(sphere_dict(radius, name, rgba), prefix=f"{name}_")
     return urdf_path
 
 

--- a/airo_models/urdf.py
+++ b/airo_models/urdf.py
@@ -175,6 +175,7 @@ def get_joint_by_name(urdf_dict: dict, joint_name: str) -> dict | None:
     """
     return _get_robot_element_by_name(urdf_dict, "joint", joint_name)
 
+
 def material_dict(rgba: tuple[float, float, float, float]) -> dict:
     material_dict = {"color": {"@rgba": " ".join(map(str, rgba))}}
     return material_dict

--- a/airo_models/urdf.py
+++ b/airo_models/urdf.py
@@ -85,7 +85,7 @@ def make_paths_absolute(dict_: dict, urdf_path: str) -> None:
                 make_paths_absolute(item, urdf_path)
 
 
-def single_link_urdf_dict(name: str, geometry_dict: dict) -> dict:
+def single_link_urdf_dict(name: str, geometry_dict: dict, material_dict: dict) -> dict:
     """Generate the basic structure of URDF for a single link with a given geometry.
 
     Corresponds to this URDF:
@@ -113,7 +113,7 @@ def single_link_urdf_dict(name: str, geometry_dict: dict) -> dict:
             "@name": name,
             "link": {
                 "@name": "base_link",
-                "visual": {"geometry": geometry_dict},
+                "visual": {"geometry": geometry_dict, "material": material_dict},
                 "collision": {"geometry": geometry_dict},
             },
         }
@@ -174,3 +174,7 @@ def get_joint_by_name(urdf_dict: dict, joint_name: str) -> dict | None:
         The URDF joint dictionary if found, otherwise None.
     """
     return _get_robot_element_by_name(urdf_dict, "joint", joint_name)
+
+def material_dict(rgba: tuple[float, float, float, float]) -> dict:
+    material_dict = {"color": {"@rgba": " ".join(map(str, rgba))}}
+    return material_dict


### PR DESCRIPTION
This PR adds an RGBA argument to the primitive URDF functions, which defaults to white (`(1.0, 1.0, 1.0, 1.0)`).

This allows for scenes like this (see code at the bottom):

![Screenshot from 2025-03-11 12-08-45](https://github.com/user-attachments/assets/3efafbd5-90c2-4e71-961b-efd151e0afe4)

This can be used for:

- when you have walls around your scene to delimit the workspace of the robot, making them transparent makes viewing the scene in meshcat easier
- highlighting specific objects, e.g., an item that the robot has selected, by giving it a specific color

Since the default value is set to white, and the argument is added as the last argument of every altered function, this change is backwards compatible.

@dnatov this PR may be of interest to you

```python
import numpy as np
from pydrake.planning import RobotDiagramBuilder
from airo_drake import add_manipulator, add_floor, add_meshcat, finish_build
from airo_drake import SingleArmScene
from pydrake.math import RigidTransform
import airo_models


robot_diagram_builder = RobotDiagramBuilder()
parser = robot_diagram_builder.parser()
parser.SetAutoRenaming(True)
plant = robot_diagram_builder.plant()
root_frame = plant.world_frame()

meshcat = add_meshcat(robot_diagram_builder)
arm_index, gripper_index = add_manipulator(robot_diagram_builder, "ur5e", "robotiq_2f_85")
add_floor(robot_diagram_builder)

# Add some spheres to the scene
colors = [
    (1.0, 0.0, 0.0, 1.0),
    (0.0, 1.0, 0.0, 1.0),
    (0.0, 0.0, 1.0, 1.0),
    (1.0, 1.0, 1.0, 1.0)
]
positions = [
    (1.0, 0.0, 0.0),
    (0.0, 1.0, 0.0),
    (0.0, 0.0, 1.0),
    (1.0, 1.0, 1.0)
]
for i, color in enumerate(colors):
    sphere_urdf_path_ = airo_models.sphere_urdf_path(0.2, f"sphere_{i}", color)
    sphere_index = parser.AddModels(sphere_urdf_path_)[0]
    sphere_frame = plant.GetFrameByName("base_link", sphere_index)
    sphere_transform = RigidTransform(p=np.array(positions[i]))
    plant.WeldFrames(root_frame, sphere_frame, sphere_transform)

# Add a semi-transparent wall
wall_urdf_path = airo_models.box_urdf_path((0.1, 0.1, 1.0), "wall", (1.0, 1.0, 1.0, 0.5))
wall_index = parser.AddModels(wall_urdf_path)[0]
wall_frame = plant.GetFrameByName("base_link", wall_index)
wall_transform = RigidTransform(p=np.array([0.5, 0.5, 0.5]))
plant.WeldFrames(root_frame, wall_frame, wall_transform)

robot_diagram, context = finish_build(robot_diagram_builder, meshcat)
```
